### PR TITLE
More Links on the Changelog Page

### DIFF
--- a/Changes.html
+++ b/Changes.html
@@ -2,73 +2,73 @@
 <h2>Changes - &szlig;60 (3490)</h2>
 
 <ul>
-<li><p>PLUGIN: Items labelled with this tag are for new/updated plugins available from http://qsapp.com/plugins</p></li>
+<li><p>PLUGIN: Items labelled with this tag are for new/updated plugins available from <a href="http://qsapp.com/plugins">http://qsapp.com/plugins</a></p></li>
 <li><p>NEW: Search by file extension. e.g. type 'mp3' will show you all .mp3s (or files with mp3 in the name)</p></li>
 <li><p>NEW: 'Delete' and 'Move to Trash' actions now give sound notification of completion (like Finder's behaviour)</p></li>
-<li><p>NEW: 'Running Applications' proxy object (Issue #221)</p></li>
-<li><p>NEW: Interfaces sorted by name within the Preferences (Issue #294)</p></li>
+<li><p>NEW: 'Running Applications' proxy object (<a href="https://github.com/quicksilver/Quicksilver/issues/221">Issue #221</a>)</p></li>
+<li><p>NEW: Interfaces sorted by name within the Preferences (<a href="https://github.com/quicksilver/Quicksilver/issues/294">Issue #294</a>)</p></li>
 <li><p>NEW: Optimisation and memory management improvements using CLang's static analyser</p></li>
-<li><p>NEW: Recent documents for applications by right arrowing into them (e.g. Preview) in 10.6 (Issue #109)</p></li>
-<li><p>NEW: Creation of 'Actions' folder in Quicksilver's support folder to make saving custom actions easier (Issue #266)</p></li>
-<li><p>NEW: Superior string sniffing. Quicksilver now knows that define:word and a.b.c.d are not a URLs. (Issue #214)</p></li>
-<li><p>NEW: Quicksilver correctly selects the 1st item in the list after using the 'show contents' action (Issue #226)</p></li>
-<li><p>NEW: &szlig;60+ versions of Quicksilver will not launch on 10.4 machines or below (Issue #279)</p></li>
-<li><p>NEW: 1st object in the results list is selected by default when viewing children of objects (Issue #226)</p></li>
-<li><p>NEW: Quicksilver source is now distributed via MacPorts (for install, see http://qsapp.com/wiki/Building_Quicksilver )</p></li>
-<li><p>NEW: Asynchronous loading of icons; no beach balling when finding file icons (Issue #98)</p></li>
-<li><p>NEW: Show link's images when browsing URLs/websites in Quicksilver (Issue #316)</p></li>
-<li><p>NEW: Web Search Icons now show the magnifying glass and the URLs favIcon (thanks to http://g.etfv.co and http://potatolondon.com) (Issue #315)</p></li>
-<li><p>NEW: Python HTML Link extractor for browsing in Quicksilver. Adds image title or alt to image labels (Issue #317)</p></li>
-<li><p>NEW: Reduced open/close/resize times for the Bezel Interface. Now feels more responsive (Issue #323)</p></li>
-<li><p>NEW: Rename action no longer selects the file extension in the 3rd pane (mimicking Finder's behaviour) (Issue #328)</p></li>
-<li><p>NEW: Preference that allows jumping to the action automatically for actions that return results (Issue #225)</p></li>
-<li><p>PLUGIN: Renamed the 'Current Webpage' proxies to reflect which browser they come from (Issue #59)</p></li>
-<li><p>PLUGIN: Fixed right arrowing into 'Current Web Page (Safari)' proxy object (Issue #59)</p></li>
+<li><p>NEW: Recent documents for applications by right arrowing into them (e.g. Preview) in 10.6 (<a href="https://github.com/quicksilver/Quicksilver/issues/109">Issue #109</a>)</p></li>
+<li><p>NEW: Creation of 'Actions' folder in Quicksilver's support folder to make saving custom actions easier (<a href="https://github.com/quicksilver/Quicksilver/issues/266">Issue #266</a>)</p></li>
+<li><p>NEW: Superior string sniffing. Quicksilver now knows that define:word and a.b.c.d are not a URLs. (<a href="https://github.com/quicksilver/Quicksilver/issues/214">Issue #214</a>)</p></li>
+<li><p>NEW: Quicksilver correctly selects the 1st item in the list after using the 'show contents' action (<a href="https://github.com/quicksilver/Quicksilver/issues/226">Issue #226</a>)</p></li>
+<li><p>NEW: &szlig;60+ versions of Quicksilver will not launch on 10.4 machines or below (<a href="https://github.com/quicksilver/Quicksilver/issues/279">Issue #279</a>)</p></li>
+<li><p>NEW: 1st object in the results list is selected by default when viewing children of objects (<a href="https://github.com/quicksilver/Quicksilver/issues/226">Issue #226</a>)</p></li>
+<li><p>NEW: Quicksilver source is now distributed via MacPorts (for install, see <a href="http://qsapp.com/plugins">http://qsapp.com/plugins</a> )</p></li>
+<li><p>NEW: Asynchronous loading of icons; no beach balling when finding file icons (<a href="https://github.com/quicksilver/Quicksilver/issues/98">Issue #98</a>)</p></li>
+<li><p>NEW: Show link's images when browsing URLs/websites in Quicksilver (<a href="https://github.com/quicksilver/Quicksilver/issues/316">Issue #316</a>)</p></li>
+<li><p>NEW: Web Search Icons now show the magnifying glass and the URLs favIcon (thanks to <a href="http://g.etfv.co">http://g.etfv.co</a> and <a href="http://qsapp.com/plugins">http://qsapp.com/plugins</a>) (<a href="https://github.com/quicksilver/Quicksilver/issues/315">Issue #315</a>)</p></li>
+<li><p>NEW: Python HTML Link extractor for browsing in Quicksilver. Adds image title or alt to image labels (<a href="https://github.com/quicksilver/Quicksilver/issues/317">Issue #317</a>)</p></li>
+<li><p>NEW: Reduced open/close/resize times for the Bezel Interface. Now feels more responsive (<a href="https://github.com/quicksilver/Quicksilver/issues/323">Issue #323</a>)</p></li>
+<li><p>NEW: Rename action no longer selects the file extension in the 3rd pane (mimicking Finder's behaviour) (<a href="https://github.com/quicksilver/Quicksilver/issues/328">Issue #328</a>)</p></li>
+<li><p>NEW: Preference that allows jumping to the action automatically for actions that return results (<a href="https://github.com/quicksilver/Quicksilver/issues/225">Issue #225</a>)</p></li>
+<li><p>PLUGIN: Renamed the 'Current Webpage' proxies to reflect which browser they come from (<a href="https://github.com/quicksilver/Quicksilver/issues/59">Issue #59</a>)</p></li>
+<li><p>PLUGIN: Fixed right arrowing into 'Current Web Page (Safari)' proxy object (<a href="https://github.com/quicksilver/Quicksilver/issues/59">Issue #59</a>)</p></li>
 <li><p>PLUGIN: Mail Module rewritten to fix right arrowing into Mail.app</p></li>
 <li><p>PLUGIN: OmniWeb plugin rewritten to be more consistent with naming of proxies and added documentation</p></li>
 <li><p>PLUGIN: UI Access plugin fixed to show icons of windows for 'Windows...' actions, speed increases</p></li>
 <li><p>PLUGIN: UI Access plugin includes a new 'Show all Menu Items' action </p></li>
-<li><p>PLUGIN: Made Window Interface appear on all spaces (Issue #61)</p></li>
+<li><p>PLUGIN: Made Window Interface appear on all spaces (<a href="https://github.com/quicksilver/Quicksilver/issues/61">Issue #61</a>)</p></li>
 <li><p>CHANGED: Task Viewer modified to make it more robust</p></li>
-<li><p>CHANGED: Localisation improvements and refactoring (Issue #260)</p></li>
-<li><p>CHANGED: Implementation of fast enumeration for easier reading and possible speed improvements (Issue #323)</p></li>
-<li><p>CHANGED: Small speed improvement to object ranking (Issue #336)</p></li>
-<li><p>CHANGED: Get Path renamed to Get Absolute Path, new Get Path action returns things like <code>~/Documents</code> (Issue #331)</p></li>
-<li><p>FIX: Crash when Quicksilver tries to combine the same object (Issue #342)</p></li>
-<li><p>FIX: Searches like "Itchy &amp; Scratchy" are now correctly passed to the browser (Issue #313)</p></li>
-<li><p>FIX: When using Quicksilver to browse the web (right arrow into URLs), the correct icons are shown (Issue #302)</p></li>
-<li><p>FIX: Websites with any top level domain (e.g. .uk) can now be browsed within Quicksilver (Issue #316)</p></li>
-<li><p>FIX: Link parser now correctly returns all the links on a page (Issue #316)</p></li>
-<li><p>FIX: Crash when changing interfaces (Issue #272)</p></li>
-<li><p>FIX: Task Viewer no longer shows 'null' when rescanning catalog entries (Issue #276)</p></li>
-<li><p>FIX: Down arrow does not wipe the result of an action, returned to Quicksilver (Issue #282)</p></li>
-<li><p>FIX: 'Latest Download' proxy no longer causes conflicts with cataloged items (Issue #308)</p></li>
-<li><p>FIX: Correct numbering of results (1 of 1) when an action returns an object to Quicksilver (Issue #282)</p></li>
-<li><p>FIX: Exception when entering nonBaseCharacters (Issue #275)</p></li>
-<li><p>FIX: TextMate String Ranker now works as previously (Issue #14)</p></li>
-<li><p>FIX: 'Type to Search' text in the command window panes (and more localisation fixes) (Issue #250)</p></li>
-<li><p>FIX: Pressing '/' to enter items could accidentally drill down to the root (Issue #63)</p></li>
+<li><p>CHANGED: Localisation improvements and refactoring (<a href="https://github.com/quicksilver/Quicksilver/issues/260">Issue #260</a>)</p></li>
+<li><p>CHANGED: Implementation of fast enumeration for easier reading and possible speed improvements (<a href="https://github.com/quicksilver/Quicksilver/issues/323">Issue #323</a>)</p></li>
+<li><p>CHANGED: Small speed improvement to object ranking (<a href="https://github.com/quicksilver/Quicksilver/issues/336">Issue #336</a>)</p></li>
+<li><p>CHANGED: Get Path renamed to Get Absolute Path, new Get Path action returns things like <code>~/Documents</code> (<a href="https://github.com/quicksilver/Quicksilver/issues/331">Issue #331</a>)</p></li>
+<li><p>FIX: Crash when Quicksilver tries to combine the same object (<a href="https://github.com/quicksilver/Quicksilver/issues/342">Issue #342</a>)</p></li>
+<li><p>FIX: Searches like "Itchy &amp; Scratchy" are now correctly passed to the browser (<a href="https://github.com/quicksilver/Quicksilver/issues/313">Issue #313</a>)</p></li>
+<li><p>FIX: When using Quicksilver to browse the web (right arrow into URLs), the correct icons are shown (<a href="https://github.com/quicksilver/Quicksilver/issues/302">Issue #302</a>)</p></li>
+<li><p>FIX: Websites with any top level domain (e.g. .uk) can now be browsed within Quicksilver (<a href="https://github.com/quicksilver/Quicksilver/issues/316">Issue #316</a>)</p></li>
+<li><p>FIX: Link parser now correctly returns all the links on a page (<a href="https://github.com/quicksilver/Quicksilver/issues/316">Issue #316</a>)</p></li>
+<li><p>FIX: Crash when changing interfaces (<a href="https://github.com/quicksilver/Quicksilver/issues/272">Issue #272</a>)</p></li>
+<li><p>FIX: Task Viewer no longer shows 'null' when rescanning catalog entries (<a href="https://github.com/quicksilver/Quicksilver/issues/276">Issue #276</a>)</p></li>
+<li><p>FIX: Down arrow does not wipe the result of an action, returned to Quicksilver (<a href="https://github.com/quicksilver/Quicksilver/issues/282">Issue #282</a>)</p></li>
+<li><p>FIX: 'Latest Download' proxy no longer causes conflicts with cataloged items (<a href="https://github.com/quicksilver/Quicksilver/issues/308">Issue #308</a>)</p></li>
+<li><p>FIX: Correct numbering of results (1 of 1) when an action returns an object to Quicksilver (<a href="https://github.com/quicksilver/Quicksilver/issues/282">Issue #282</a>)</p></li>
+<li><p>FIX: Exception when entering nonBaseCharacters (<a href="https://github.com/quicksilver/Quicksilver/issues/275">Issue #275</a>)</p></li>
+<li><p>FIX: TextMate String Ranker now works as previously (<a href="https://github.com/quicksilver/Quicksilver/issues/14">Issue #14</a>)</p></li>
+<li><p>FIX: 'Type to Search' text in the command window panes (and more localisation fixes) (<a href="https://github.com/quicksilver/Quicksilver/issues/250">Issue #250</a>)</p></li>
+<li><p>FIX: Pressing '/' to enter items could accidentally drill down to the root (<a href="https://github.com/quicksilver/Quicksilver/issues/63">Issue #63</a>)</p></li>
 <li><p>FIX: The about window stops rendering images when closed</p></li>
-<li><p>FIX: Assignment of mailto: strings as objects with Email actions (Issue #267)</p></li>
-<li><p>FIX: Always display the interface when Quicksilver returns a result (Issue #232)</p></li>
+<li><p>FIX: Assignment of mailto: strings as objects with Email actions (<a href="https://github.com/quicksilver/Quicksilver/issues/267">Issue #267</a>)</p></li>
+<li><p>FIX: Always display the interface when Quicksilver returns a result (<a href="https://github.com/quicksilver/Quicksilver/issues/232">Issue #232</a>)</p></li>
 <li><p>FIX: URLs with &lt;>|#"?$! characters are parsed properly </p></li>
 <li><p>FIX: Copy To... action only shows folders in the 3rd pane</p></li>
-<li><p>FIX: 'Visible Applications' proxy displays only apps that aren't hidden (Issue #221)</p></li>
-<li><p>FIX: Bezel and Primer interface names display correctly in the preferences (Issue #190)</p></li>
-<li><p>FIX: Changing interface properly registers '.' as a special character to enter text mode (Issue #233)</p></li>
+<li><p>FIX: 'Visible Applications' proxy displays only apps that aren't hidden (<a href="https://github.com/quicksilver/Quicksilver/issues/221">Issue #221</a>)</p></li>
+<li><p>FIX: Bezel and Primer interface names display correctly in the preferences (<a href="https://github.com/quicksilver/Quicksilver/issues/190">Issue #190</a>)</p></li>
+<li><p>FIX: Changing interface properly registers '.' as a special character to enter text mode (<a href="https://github.com/quicksilver/Quicksilver/issues/233">Issue #233</a>)</p></li>
 <li><p>FIX: Incorrect size settings for two .xibs</p></li>
-<li><p>FIX: Size of result window remembered on relaunch (Issue #176)</p></li>
-<li><p>FIX: Possible crashes when installing plugins (Issue #241)</p></li>
-<li><p>FIX: 1st pane (and comma items) are cleared when an action returns an object (Issue #203)</p></li>
-<li><p>FIX: Primer interface appears on all spaces (Issue #64)</p></li>
-<li><p>FIX: Preference pane appears on all spaces (Issue #64)</p></li>
-<li><p>FIX: Result window size saved on relaunch (Issue #176)</p></li>
-<li><p>FIX: Get Path action returns strings instead of files (Issue #182)</p></li>
-<li><p>FIX: Get Path action works with the comma trick (Issue #203)</p></li>
-<li><p>FIX: Search results 'x of y' showing correctly in the result window (Issue #207)</p></li>
-<li><p>FIX: Clicking 'Defaults' in the Appearance Preferences would crash Quicksilver (Issue #212)</p></li>
-<li><p>FIX: PlugIn file path renamed correctly for compilation on case-sensitive systems (MacPorts) (Issue #309)</p></li>
-<li><p>FIX: Compilation fixes for 10.5 and isSnowLeopard method (moved to a new class) (Issue #287)</p></li>
+<li><p>FIX: Size of result window remembered on relaunch (<a href="https://github.com/quicksilver/Quicksilver/issues/176">Issue #176</a>)</p></li>
+<li><p>FIX: Possible crashes when installing plugins (<a href="https://github.com/quicksilver/Quicksilver/issues/241">Issue #241</a>)</p></li>
+<li><p>FIX: 1st pane (and comma items) are cleared when an action returns an object (<a href="https://github.com/quicksilver/Quicksilver/issues/203">Issue #203</a>)</p></li>
+<li><p>FIX: Primer interface appears on all spaces (<a href="https://github.com/quicksilver/Quicksilver/issues/64">Issue #64</a>)</p></li>
+<li><p>FIX: Preference pane appears on all spaces (<a href="https://github.com/quicksilver/Quicksilver/issues/64">Issue #64</a>)</p></li>
+<li><p>FIX: Result window size saved on relaunch (<a href="https://github.com/quicksilver/Quicksilver/issues/176">Issue #176</a>)</p></li>
+<li><p>FIX: Get Path action returns strings instead of files (<a href="https://github.com/quicksilver/Quicksilver/issues/182">Issue #182</a>)</p></li>
+<li><p>FIX: Get Path action works with the comma trick (<a href="https://github.com/quicksilver/Quicksilver/issues/203">Issue #203</a>)</p></li>
+<li><p>FIX: Search results 'x of y' showing correctly in the result window (<a href="https://github.com/quicksilver/Quicksilver/issues/207">Issue #207</a>)</p></li>
+<li><p>FIX: Clicking 'Defaults' in the Appearance Preferences would crash Quicksilver (<a href="https://github.com/quicksilver/Quicksilver/issues/212">Issue #212</a>)</p></li>
+<li><p>FIX: PlugIn file path renamed correctly for compilation on case-sensitive systems (MacPorts) (<a href="https://github.com/quicksilver/Quicksilver/issues/309">Issue #309</a>)</p></li>
+<li><p>FIX: Compilation fixes for 10.5 and isSnowLeopard method (moved to a new class) (<a href="https://github.com/quicksilver/Quicksilver/issues/287">Issue #287</a>)</p></li>
 </ul>
 
 <p>Special thanks to:<br/ >
@@ -136,13 +136,13 @@
 
 <p>Jeff Cox for his support for the development team.</p>
 
-<p>Philip Dooher for setting up @LoveQuicksilver &amp; lovequicksilver.com.</p>
+<p>Philip Dooher for setting up @LoveQuicksilver &amp; <a href="http://lovequicksilver.com/">lovequicksilver.com</a>.</p>
 
 <p>Patrick Robertson for initiating QSApp.com.</p>
 
 <p>Rob McBroom for his Plugin Development documentation.</p>
 
-<p>All contributors to the Wiki at http://qsapp.com/wiki.</p>
+<p>All contributors to the Wiki at <a href="http://qsapp.com/wiki">http://qsapp.com/wiki</a>.</p>
 
 <p>GitHub for hosting the source and downloads.</p>
 


### PR DESCRIPTION
Changed all references to issues into links to the issues (it seems some of them are misnumbered; didn't try to fix that), and turned several URLs into links.
