### PR TITLE
Avoid warning messages if changelog can not be loaded

### DIFF
--- a/changelog.php
+++ b/changelog.php
@@ -1,41 +1,30 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-    <head>
+	<head>
   		<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-        <meta http-equiv="Content-Language" content="en" />
-        <meta content="" name="description" />
-        <meta name="Keywords" content="" />
-        <title>Quicksilver &#151; Changelog</title>
-
+		<meta http-equiv="Content-Language" content="en" />
+		<meta content="" name="description" />
+		<meta name="Keywords" content="" />
+		<title>Quicksilver &#151; Changelog</title>
 		<?php include('template/head.tpl'); ?>
-
-    </head>
-    
-    <body>
-      <div id="Container">
-      <?php include('template/logo.tpl'); ?>
-
-		<?php include('template/nav.tpl'); ?>
-                
+	</head>
+	<body>
+		<div id="Container">
+			<?php include('template/logo.tpl'); ?>
+			<?php include('template/nav.tpl'); ?>
 			<div id="Page-Top"></div>
-			
-            <div id="Page">
-			<h1>Quicksilver Changelog</h1>
-			
-										<div class="Page-Break"></div>
-
-<?php include('ChangesBare.html'); ?>
-
-				
-				<div class="Page-Break"></div>
-				
-            </div> <!-- Page -->
-
+			<div id="Page">
+				<h1>Quicksilver Changelog</h1>
+					<div class="Page-Break"></div>
+					<?php 
+						// This only works on production
+						@include('ChangesBare.html');
+					?>
+					<div class="Page-Break"></div>
+			</div>
 			<div id="Page-Bottom"></div>
-			
-				<?php include('template/footer.tpl'); ?>
-
-        </div> <!-- Container -->
-    </body>
+			<?php include('template/footer.tpl'); ?>
+		</div>
+	</body>
 </html>


### PR DESCRIPTION
The `/changelog.php` url allows you to view the changelog of the application. However, to work it requires files that are not available in the repository. This causes a warning message in development environments.

With this change, the warning message is no longer displayed.