### PR TITLE
Hides navbar link to Twitter

### DIFF
--- a/template/nav.tpl
+++ b/template/nav.tpl
@@ -6,7 +6,7 @@
 		array("url"=>"/donate.php", "label"=>"Donate", "openInNewTab"=>false),
 		array("url"=>"/plugins.php", "label"=>"Plugins", "openInNewTab"=>false),
 		array("url"=>"/support.php", "label"=>"Support", "openInNewTab"=>false),
-		array("url"=>"http://twitter.com/lovequicksilver", "label"=>"Twitter", "openInNewTab"=>true),
+		//array("url"=>"http://twitter.com/lovequicksilver", "label"=>"Twitter", "openInNewTab"=>true),
 	);
 
 	$scriptName = $_SERVER['SCRIPT_NAME'];


### PR DESCRIPTION
Related to https://github.com/quicksilver/Quicksilver/issues/2554 


This PR hides the Twitter link in the main navigation bar.

This is how look after hides that link: 
![Captura de pantalla 2021-06-09 a las 0 36 14](https://user-images.githubusercontent.com/6883041/121266383-b4ef8380-c8ba-11eb-812b-dd1c7aae90f8.png)
