### PR TITLE
Fix GMail search URL

### DIFF
--- a/qs0/plugin-data/web-search-list.php
+++ b/qs0/plugin-data/web-search-list.php
@@ -94,7 +94,7 @@ echo ' <div class="QSWebSearchContentStart"></div>
                 <a href="qss-http://www.google.'.$tld.'/search?q=***&ie=UTF-8&oe=UTF-8">Google ('.$country.')</a>
             </li>
             <li>
-                <a href="qss-https://mail.google.com/mail/?search=query&amp;view=tl&amp;start=0&amp;init=1&amp;fs=1&amp;q=***">Gmail</a>
+                <a href="qss-https://mail.google.com/mail/#search/***">Gmail</a>
             </li>
             <li>
                 <a href="qss-http://maps.google.'.$tld.'/maps?q=***">Google Maps ('.$country.')</a>


### PR DESCRIPTION
At some point the search URL appears to have changed and no longer requires most of these parameters. In fact as it stands this URL doesn't even result in a functioning search for me whereas the new URL included in this PR does.

![image](https://user-images.githubusercontent.com/34676/169660777-e17aceae-cd4d-4767-9ab1-815e091a4c1c.png)
